### PR TITLE
Removed `Html` from `def programming_languages(self)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ class el0xren():
         self.language = ['Lithuanian', 'English', 'Russian(a bit)']
     def programming_languages(self):
         return [
-            'Python', 'Bash', 'html', 'Shell', 'JavaScript'
+            'Python', 'Bash', 'Shell', 'JavaScript'
         ]
     def developer_tools(self):
         return [


### PR DESCRIPTION
Since it's not a programming language but a markup language, it could be the best for the integrity of your README.md.

/s Just kidding, who gives a crap about it. ツ